### PR TITLE
Wrapped the state update that opens prompts in a setTimeout.

### DIFF
--- a/src/components/hooks/Prompt.tsx
+++ b/src/components/hooks/Prompt.tsx
@@ -9,7 +9,7 @@ interface IPromptState {
 export default function usePrompt() {
 	const [prompt, setPrompt] = useState<IPromptState>({ open: false, msg: '' })
 	const openPrompt = (msg: string) => {
-		setPrompt({ open: true, msg })
+		setTimeout(() => setPrompt({ open: true, msg }))
 	}
 	const closePrompt = () => {
 		setPrompt({ open: false, msg: '' })


### PR DESCRIPTION
React native seems to crap out when attempting to render modals concurrently. There is a discussion about it [here](https://github.com/react-native-modal/react-native-modal/issues/30) (that's not on the react-native repo but it talks about the framework limitations) and some related issues reported in the official repo [here](https://github.com/facebook/react-native/issues?q=is%3Aissue+multiple+modal++ios+label%3A%22Component%3A+Modal%22).

To avoid these problems I just wrapped the 'setPrompt' state change in a setTimeout. For some reason the modals don't get stuck transitioning one after the other when 'transparent' is set to false on 'Modal' but I haven't looked too much into the React Native codebase to see why. The change in this PR should work though.

Addresses #9 