### PR TITLE
hide memo if it is an empty string Fixes #171

### DIFF
--- a/src/components/ClipboardModal.tsx
+++ b/src/components/ClipboardModal.tsx
@@ -21,7 +21,9 @@ export default function ClipboardModal() {
 				{t('foundCashuClipboard')}
 			</Text>
 			<Text style={globals(color, highlight).modalTxt}>
-				{t('memo', { ns: NS.history })}: {tokenInfo.decoded.memo}{'\n'}
+				{tokenInfo.decoded.memo && tokenInfo.decoded.memo.length > 0 &&
+					<>{t('memo', { ns: NS.history })}: {tokenInfo.decoded.memo}{'\n'}</>
+				}
 				<Txt
 					txt={formatInt(tokenInfo.value)}
 					styles={[{ fontWeight: '500' }]}


### PR DESCRIPTION
When the app comes back to the foreground and the user has a token in its clipboard, a modal pops up showing the token and asking user to claim. This modal was showing the memo section even if there is no memo.