### PR TITLE
disable clipboard check in foreground on ios

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -175,11 +175,11 @@ function _App() {
 				appState.current.match(/inactive|background/) &&
 				nextAppState === 'active'
 			) {
-				l('App has come to the foreground!')
+				l('[PIN] App has come to the foreground!')
 				// check for pin attempts and app locked state
 				await handlePinForeground()
 			} else {
-				l('App has gone to the background!')
+				l('[PIN] App has gone to the background!')
 				// store timestamp to activate auth after > 5mins in background
 				await store.set(STORE_KEYS.bgCounter, `${Math.ceil(Date.now() / 1000)}`)
 			}

--- a/src/context/FocusClaim.tsx
+++ b/src/context/FocusClaim.tsx
@@ -1,4 +1,5 @@
 import { getEncodedToken } from '@cashu/cashu-ts'
+import { isIOS } from '@consts'
 import { getMintsUrls } from '@db'
 import { l } from '@log'
 import type { ITokenInfo } from '@model'
@@ -105,24 +106,27 @@ const useFocusClaim = () => {
 	}
 
 	useEffect(() => {
+		// disable foreground claim on iOS
+		if (isIOS) { return }
 		// eslint-disable-next-line @typescript-eslint/no-misused-promises
 		const subscription = AppState.addEventListener('change', async nextAppState => {
 			if (
 				appState.current.match(/inactive|background/) &&
 				nextAppState === 'active'
 			) {
-				l('App has come to the foreground!')
+				l('[Claim token] App has come to the foreground!')
 				setClaimed(false)
 				// check for clipboard valid cashu token when the app comes to the foregorund
 				await handleForeground()
 			} else {
-				l('App has gone to the background!')
+				l('[Claim token] App has gone to the background!')
 			}
 			appState.current = nextAppState
 		})
 		return () => subscription.remove()
 	// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [])
+
 	return {
 		claimed,
 		setClaimed,


### PR DESCRIPTION
After the app comes to the foreground, it keeps prompting the user to "allow enuts to paste" even if the. This feature is now diabled on ios until a better solution is available. Fixes #164 