### PR TITLE
fix(ui): use x in onboarding-checkbox

### DIFF
--- a/src/screens/Onboarding.tsx
+++ b/src/screens/Onboarding.tsx
@@ -54,13 +54,29 @@ export default function OnboardingScreen({ navigation }: TOnboardingPageProps) {
               >
                 <View
                   style={{
-                    width: s(10),
-                    borderWidth: 1,
+                    width: s(16),
+                    height: s(16),
+                    borderWidth: 1.5,
                     borderColor: "white",
-                    height: s(10),
-                    backgroundColor: accepted ? "white" : "transparent",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    borderRadius: 2,
                   }}
-                />
+                >
+                  {accepted && (
+                    <Txt
+                      txt="✕"
+                      styles={[
+                        {
+                          fontSize: s(12),
+                          lineHeight: s(14),
+                          fontWeight: "bold",
+                          color: "white",
+                        },
+                      ]}
+                    />
+                  )}
+                </View>
                 <Txt txt="I understand" styles={[{ marginLeft: s(10) }]} />
               </TouchableOpacity>
             </View>


### PR DESCRIPTION
- use an x inside the onboarding checkbox to add more visual contrast when the box is checked.

This should resolve #405 

<img width="1080" height="2400" alt="eNuts_bug_android16" src="https://github.com/user-attachments/assets/233a7d37-1d91-473c-ba9f-ff55a0c73843" />

(the image is built on top of the suggested changes in #406)